### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ## Disclaimer
 This project includes [code](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/slack) originally developed by Anthropic and released under the MIT License. Substantial modifications and new functionality have been added by For Good AI Inc. (dba Zencoder Inc.), and are licensed under the Apache License, Version 2.0.
 
+<a href="https://glama.ai/mcp/servers/@zencoderai/slack-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zencoderai/slack-mcp-server/badge" alt="Slack MCP server" />
+</a>
+
 ## Overview
 A Model Context Protocol (MCP) server for interacting with Slack workspaces. This server provides tools to list channels, post messages, reply to threads, add reactions, get channel history, and manage users.
 


### PR DESCRIPTION
This PR adds a badge for the [Slack](https://glama.ai/mcp/servers/@zencoderai/slack-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zencoderai/slack-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zencoderai/slack-mcp-server/badge" alt="Slack MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.