### PR TITLE
Fix: Format thread_ts parameter for proper Slack API thread replies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -60,6 +60,21 @@ export class SlackClient {
     };
   }
 
+  /**
+   * Format thread_ts to ensure it has the decimal point in the correct position
+   * Slack expects format like "1234567890.123456" (timestamp with period before last 6 digits)
+   */
+  private formatThreadTs(thread_ts: string): string {
+    if (!thread_ts.includes('.')) {
+      // If no period, add it so that 6 digits come after it
+      if (thread_ts.length >= 7) {
+        const insertPosition = thread_ts.length - 6;
+        return thread_ts.slice(0, insertPosition) + '.' + thread_ts.slice(insertPosition);
+      }
+    }
+    return thread_ts;
+  }
+
   async getChannels(limit: number = 100, cursor?: string): Promise<any> {
     const predefinedChannelIds = process.env.SLACK_CHANNEL_IDS;
     if (!predefinedChannelIds) {
@@ -131,7 +146,7 @@ export class SlackClient {
       headers: this.botHeaders,
       body: JSON.stringify({
         channel: channel_id,
-        thread_ts: thread_ts,
+        thread_ts: this.formatThreadTs(thread_ts),
         text: text,
       }),
     });
@@ -177,7 +192,7 @@ export class SlackClient {
   async getThreadReplies(channel_id: string, thread_ts: string): Promise<any> {
     const params = new URLSearchParams({
       channel: channel_id,
-      ts: thread_ts,
+      ts: this.formatThreadTs(thread_ts),
     });
 
     const response = await fetch(


### PR DESCRIPTION
## Problem

The `slack_reply_to_thread` tool was posting messages as new top-level messages instead of actual thread replies, particularly in DM channels. The root cause was that the `thread_ts` parameter wasn't being properly formatted before being sent to Slack's `chat.postMessage` API.

## Root Cause

The tool description in the original codebase mentioned that timestamps could be provided without a decimal point and "can be converted by adding the period such that 6 numbers come after it," but the code never actually implemented this conversion. Slack expects timestamps in the format `1234567890.123456` (with exactly 6 digits after the decimal point), but unformatted timestamps like `1234567890123456` were being passed directly to the API, causing Slack to ignore the `thread_ts` parameter and post as top-level messages instead.

## Solution

This PR adds proper `thread_ts` formatting:

1. **New helper method**: `formatThreadTs()` - validates and formats timestamps to ensure they have the decimal point in the correct position
2. **Applied to both methods**: Updated `postReply()` and `getThreadReplies()` to use the formatter
3. **Backward compatible**: Properly formatted timestamps pass through unchanged
4. **Automatic conversion**: Timestamps without decimal points are automatically formatted correctly

## Testing

While we cannot run live tests without a Slack workspace in CI, the fix addresses the documented behavior and aligns with Slack's API requirements. Testing confirmed that raw `curl` calls with properly formatted `thread_ts` work perfectly, validating that the issue was in the parameter formatting, not the API call structure.

## Changes

- Added `formatThreadTs()` private method to `SlackClient` class
- Updated `postReply()` to format `thread_ts` before sending to Slack API
- Updated `getThreadReplies()` to format `thread_ts` before querying threads
- Code compiles successfully with TypeScript

## Impact

This fix ensures that existing users can reliably use thread replies in all channel types, including DMs, which was previously broken when timestamps were provided without proper formatting.